### PR TITLE
Fix fixlocalvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Path to output file. If file is already exists in path, that will be erased.
 ### --thread (Optional, Default=8)
 Number of thread used for apply mapping to class.
 
-### --fixLocalVar (Optional, Default=no)
+### --fixlocalvar (Optional, Default=no)
 Fix local variable name \u2603(☃). This variable name is declared multiple time in same scope, so some decompiler does not work. There are three options.
 
 |option|description|
@@ -66,6 +66,6 @@ Reobf option reverse mapping direction. By default, MC-Remapper map obfuscated c
 ## Example usage
 
 ```
-./MC-Remapper --mapping https://launcher.mojang.com/v1/objects/448ccb7b455f156bb5cb9cdadd7f96cd68134dbd/server.txt --input server.jar --output deobf.jar --thread 8 --fixLocalVar=delete
+./MC-Remapper --mapping https://launcher.mojang.com/v1/objects/448ccb7b455f156bb5cb9cdadd7f96cd68134dbd/server.txt --input server.jar --output deobf.jar --thread 8 --fixlocalvar=delete
 ```
 

--- a/src/main/kotlin/io/github/readymadeprogrammer/mcremapper/App.kt
+++ b/src/main/kotlin/io/github/readymadeprogrammer/mcremapper/App.kt
@@ -20,7 +20,7 @@ class App : CliktCommand() {
     val output: File by option().file(exists = false).required()
     val reobf: Boolean by option().flag()
     val thread: Int by option().int().default(8)
-    val fixLocalVar: LocalVarFixType by option().choice("no", "rename", "delete").convert {
+    val fixlocalvar: LocalVarFixType by option().choice("no", "rename", "delete").convert {
         when (it) {
             "no" -> LocalVarFixType.NO_FIX
             "rename" -> LocalVarFixType.RENAME

--- a/src/main/kotlin/io/github/readymadeprogrammer/mcremapper/SimpleClassRemapper.kt
+++ b/src/main/kotlin/io/github/readymadeprogrammer/mcremapper/SimpleClassRemapper.kt
@@ -30,9 +30,9 @@ class SimpleClassRemapper(cv: ClassVisitor, remapper: Remapper) : ClassRemapper(
 class LocalVarFixMethodRemapper(mv: MethodVisitor, remapper: Remapper) : MethodRemapper(mv, remapper) {
     override fun visitLocalVariable(name: String?, desc: String?, signature: String?, start: Label?, end: Label?, index: Int) {
         if (name != null && name == "\u2603") {
-            if (app.fixLocalVar == LocalVarFixType.RENAME)
+            if (app.fixlocalvar == LocalVarFixType.RENAME)
                 super.visitLocalVariable("debug$index", desc, signature, start, end, index)
-            else if (app.fixLocalVar == LocalVarFixType.NO_FIX)
+            else if (app.fixlocalvar == LocalVarFixType.NO_FIX)
                 super.visitLocalVariable(name, desc, signature, start, end, index)
         } else {
             super.visitLocalVariable(name, desc, signature, start, end, index)


### PR DESCRIPTION
The option `fixLocalVar` is unusable when it is written in camelCase. This PR should fix it.